### PR TITLE
fix song title element detection on intl lang

### DIFF
--- a/SpotifyGeniusLyrics.user.js
+++ b/SpotifyGeniusLyrics.user.js
@@ -379,10 +379,15 @@ function listSongs (hits, container, query) {
   }
 }
 
-const songTitleQuery = 'a[data-testid="nowplaying-track-link"],.Root footer .ellipsis-one-line a[href^="/track/"],.Root footer .ellipsis-one-line a[href^="/album/"],.Root footer .standalone-ellipsis-one-line a[href^="/album/"],[data-testid="context-item-info-title"] a[href^="/album/"],[data-testid="context-item-info-title"] a[href^="/track/"]'
+const songTitleQuery = 'a[data-testid="nowplaying-track-link"],.Root footer .ellipsis-one-line a[href*="/track/"],.Root footer .ellipsis-one-line a[href*="/album/"],.Root footer .standalone-ellipsis-one-line a[href*="/album/"],[data-testid="context-item-info-title"] a[href*="/album/"],[data-testid="context-item-info-title"] a[href*="/track/"]'
 
 function getSongTitleAndArtist () {
-  let songTitle = document.querySelector(songTitleQuery).innerText
+  const songTitleDOM = document.querySelector(songTitleQuery)
+  if (!songTitleDOM) {
+    console.warn('The song title element is not found.')
+    return
+  }
+  let songTitle = songTitleDOM.innerText
   songTitle = genius.f.cleanUpSongTitle(songTitle)
   const songArtistsArr = []
   document.querySelectorAll('.Root footer .ellipsis-one-line a[href^="/artist/"],.Root footer .standalone-ellipsis-one-line a[href^="/artist/"],a[data-testid="context-item-info-artist"][href^="/artist/"],[data-testid="context-item-info-artist"] a[href^="/artist/"]').forEach((e) => songArtistsArr.push(e.innerText))

--- a/SpotifyGeniusLyrics.user.js
+++ b/SpotifyGeniusLyrics.user.js
@@ -390,7 +390,9 @@ function getSongTitleAndArtist () {
   let songTitle = songTitleDOM.innerText
   songTitle = genius.f.cleanUpSongTitle(songTitle)
   const songArtistsArr = []
-  document.querySelectorAll('.Root footer .ellipsis-one-line a[href^="/artist/"],.Root footer .standalone-ellipsis-one-line a[href^="/artist/"],a[data-testid="context-item-info-artist"][href^="/artist/"],[data-testid="context-item-info-artist"] a[href^="/artist/"]').forEach((e) => songArtistsArr.push(e.innerText))
+  for (const e of document.querySelectorAll('.Root footer .ellipsis-one-line a[href*="/artist/"],.Root footer .standalone-ellipsis-one-line a[href*="/artist/"],a[data-testid="context-item-info-artist"][href*="/artist/"],[data-testid="context-item-info-artist"] a[href*="/artist/"]')) {
+    songArtistsArr.push(e.innerText)
+  }
   return [songTitle, songArtistsArr]
 }
 


### PR DESCRIPTION
The script was unable to detect the song if Spotify is in a language other than English.

Example: [/track/2VBLFxCUyFp5BfmsZpxcis](https://open.spotify.com/track/2VBLFxCUyFp5BfmsZpxcis), [/intl-ja/album/1xml9CR90tJdvTESDk4Q4s](https://open.spotify.com/intl-ja/album/1xml9CR90tJdvTESDk4Q4s)

<img width="1512" alt="Screen Shot 2023-06-28 at 7 12 11" src="https://github.com/cvzi/Spotify-Genius-Lyrics-userscript/assets/44498510/cc23d2b3-4253-40a3-9b11-5a0c547be553">
