### PR TITLE
fix `getSongTitleAndArtist()`

### DIFF
--- a/SpotifyGeniusLyrics.user.js
+++ b/SpotifyGeniusLyrics.user.js
@@ -380,18 +380,24 @@ function listSongs (hits, container, query) {
 }
 
 const songTitleQuery = 'a[data-testid="nowplaying-track-link"],.Root footer .ellipsis-one-line a[href*="/track/"],.Root footer .ellipsis-one-line a[href*="/album/"],.Root footer .standalone-ellipsis-one-line a[href*="/album/"],[data-testid="context-item-info-title"] a[href*="/album/"],[data-testid="context-item-info-title"] a[href*="/track/"]'
+const songArtistsQuery = '.Root footer .ellipsis-one-line a[href*="/artist/"],.Root footer .standalone-ellipsis-one-line a[href*="/artist/"],a[data-testid="context-item-info-artist"][href*="/artist/"],[data-testid="context-item-info-artist"] a[href*="/artist/"]'
 
 function getSongTitleAndArtist () {
-  const songTitleDOM = document.querySelector(songTitleQuery)
+  const nowPlayingFooter = document.querySelector('footer[data-testid="now-playing-bar"]')
+  const songTitleDOM = nowPlayingFooter ? HTMLElement.prototype.querySelector.call(nowPlayingFooter, songTitleQuery) : document.querySelector(songTitleQuery) // eslint-disable-line no-undef
   if (!songTitleDOM) {
     console.warn('The song title element is not found.')
     return
   }
-  let songTitle = songTitleDOM.innerText
-  songTitle = genius.f.cleanUpSongTitle(songTitle)
+  const songTitle = genius.f.cleanUpSongTitle(songTitleDOM.textContent)
+  if (!songTitle) {
+    console.warn('The song title is empty.')
+    return
+  }
   const songArtistsArr = []
-  for (const e of document.querySelectorAll('.Root footer .ellipsis-one-line a[href*="/artist/"],.Root footer .standalone-ellipsis-one-line a[href*="/artist/"],a[data-testid="context-item-info-artist"][href*="/artist/"],[data-testid="context-item-info-artist"] a[href*="/artist/"]')) {
-    songArtistsArr.push(e.innerText)
+  const ArtistLinks = nowPlayingFooter ? HTMLElement.prototype.querySelectorAll.call(nowPlayingFooter, songArtistsQuery) : document.querySelectorAll(songArtistsQuery) // eslint-disable-line no-undef
+  for (const e of ArtistLinks) {
+    songArtistsArr.push(e.textContent)
   }
   return [songTitle, songArtistsArr]
 }


### PR DESCRIPTION
The current implementation for `getSongTitleAndArtist()` will get wrong results if "Now Playing View" is shown.

**"Now Playing View"**
<img width="167" alt="Screen Shot 2023-07-22 at 17 53 56" src="https://github.com/cvzi/Spotify-Genius-Lyrics-userscript/assets/44498510/c7ab4e73-31e1-4370-8193-f4ffc0d3ec42">




Since I am not familiar with Spotify layout, I just do the minimum change to make it correct. 

<img width="1466" alt="Screen Shot 2023-07-22 at 17 45 36" src="https://github.com/cvzi/Spotify-Genius-Lyrics-userscript/assets/44498510/4f6bb26d-ff8c-4f74-8c3e-9ce00646e4e9">


<img width="1463" alt="Screen Shot 2023-07-22 at 17 45 29" src="https://github.com/cvzi/Spotify-Genius-Lyrics-userscript/assets/44498510/3c46fb42-81f7-4eaf-8e1e-07e309fe3d53">


@cvzi You might further review how to avoid the wrong selection of elements.